### PR TITLE
downgrading carbon-parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2</groupId>
         <artifactId>wso2</artifactId>
-        <version>4</version>
+        <version>3</version>
     </parent>
 
     <groupId>org.wso2.carbon.jndi</groupId>


### PR DESCRIPTION
Adding {maven-resources} is removed from carbon-parent new version (version 4). We need to include a maven resource to org.wso2.carbon.jndi-1.0.0-SNAPSHOT.jar. Hence downgrading parent version.
