### PR TITLE
Add JNDI context factory for "rmi:" namespace

### DIFF
--- a/components/org.wso2.carbon.jndi/src/main/java/org/wso2/carbon/jndi/internal/JNDIActivator.java
+++ b/components/org.wso2.carbon.jndi/src/main/java/org/wso2/carbon/jndi/internal/JNDIActivator.java
@@ -27,7 +27,7 @@ import org.wso2.carbon.jndi.internal.java.JavaURLContextFactory;
 import org.wso2.carbon.jndi.internal.osgi.JNDIContextManagerServiceFactory;
 import org.wso2.carbon.jndi.internal.osgi.OSGiURLContextServiceFactory;
 import org.wso2.carbon.jndi.internal.osgi.builder.DefaultContextFactoryBuilder;
-import org.wso2.carbon.jndi.internal.osgi.builder.DefaultObjectFactoryBuilder;
+import org.wso2.carbon.jndi.internal.rmi.RMIURLContextFactory;
 
 import java.util.Dictionary;
 import java.util.Hashtable;
@@ -50,11 +50,14 @@ public class JNDIActivator implements BundleActivator {
 
         try {
             NamingManager.setInitialContextFactoryBuilder(new DefaultContextFactoryBuilder());
-            NamingManager.setObjectFactoryBuilder(new DefaultObjectFactoryBuilder());
 
             Dictionary<String, String> propertyMap = new Hashtable<>();
             propertyMap.put(JNDIConstants.JNDI_URLSCHEME, "java");
             bundleContext.registerService(ObjectFactory.class, new JavaURLContextFactory(), propertyMap);
+
+            Dictionary<String, String> rmiPropertyMap = new Hashtable<>();
+            rmiPropertyMap.put(JNDIConstants.JNDI_URLSCHEME, "rmi");
+            bundleContext.registerService(ObjectFactory.class, new RMIURLContextFactory(), rmiPropertyMap);
 
             //register osgi url scheme
             Dictionary<String, String> osgiPropertyMap = new Hashtable<>();

--- a/components/org.wso2.carbon.jndi/src/main/java/org/wso2/carbon/jndi/internal/rmi/RMIURLContextFactory.java
+++ b/components/org.wso2.carbon.jndi/src/main/java/org/wso2/carbon/jndi/internal/rmi/RMIURLContextFactory.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.jndi.internal.rmi;
+
+import com.sun.jndi.url.rmi.rmiURLContext;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NamingException;
+import javax.naming.spi.ObjectFactory;
+
+/**
+ * Context factory for the "rmi:" namespace.
+ * <p>
+ * <b>Important note</b> : This factory MUST be associated with the "rmi" URL
+ * prefix, which can be done by either :
+ * <ul>
+ * <li>Adding a
+ * java.jndi.factory.url.pkgs=org.apache.jndi property
+ * to the JNDI properties file</li>
+ * <li>Setting an environment variable named Context.URL_PKG_PREFIXES with
+ * its value including the org.apache.jndi package name.
+ * More detail about this can be found in the JNDI documentation :
+ * {@link javax.naming.spi.NamingManager#getURLContext(java.lang.String, java.util.Hashtable)}.</li>
+ * </ul>
+ */
+public class RMIURLContextFactory implements ObjectFactory {
+
+    protected static volatile Context rmiInitialContext = null;
+
+    @Override
+    public synchronized Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment)
+            throws NamingException {
+        if (rmiInitialContext == null) {
+            rmiInitialContext = new rmiURLContext(environment);
+        }
+        return rmiInitialContext;
+    }
+}

--- a/components/org.wso2.carbon.jndi/src/main/java/org/wso2/carbon/jndi/internal/rmi/package.html
+++ b/components/org.wso2.carbon.jndi/src/main/java/org/wso2/carbon/jndi/internal/rmi/package.html
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+    WSO2 Inc. licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<body>
+
+<p>This package contains the URL context factory for the "rmi" namespace.</p>
+
+<p></p>
+
+</body>


### PR DESCRIPTION
## Purpose
This PR introduces an initial context factory for "rmi:" namespace.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes