### PR TITLE
Fix NotContextException when using with LDAP

### DIFF
--- a/components/org.wso2.carbon.jndi/src/main/java/org/wso2/carbon/jndi/internal/osgi/WrapperContext.java
+++ b/components/org.wso2.carbon.jndi/src/main/java/org/wso2/carbon/jndi/internal/osgi/WrapperContext.java
@@ -37,6 +37,11 @@ import javax.naming.NameParser;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.NoInitialContextException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.ModificationItem;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
 import javax.naming.spi.ObjectFactory;
 
 import static org.wso2.carbon.jndi.internal.Constants.OSGI_JNDI_URL_SCHEME;
@@ -48,7 +53,7 @@ import static org.wso2.carbon.jndi.internal.util.LambdaExceptionUtils.rethrowSup
 /**
  * Wrapper for JNDI Context implementation.
  */
-public class WrapperContext implements Context {
+public class WrapperContext implements Context, DirContext {
 
     private static final Logger logger = LoggerFactory.getLogger(WrapperContext.class);
 
@@ -717,6 +722,186 @@ public class WrapperContext implements Context {
     private Context getDefaultBackingContext() throws NamingException {
         backingContext.orElseThrow(NoInitialContextException::new);
         return backingContext.get();
+    }
+
+    @Override
+    public Attributes getAttributes(Name name) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).getAttributes(name);
+        return null;
+    }
+
+    @Override
+    public Attributes getAttributes(String name) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).getAttributes(name);
+        return null;
+    }
+
+    @Override
+    public Attributes getAttributes(Name name, String[] attrIds) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).getAttributes(name, attrIds);
+        return null;
+    }
+
+    @Override
+    public Attributes getAttributes(String name, String[] attrIds) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).getAttributes(name, attrIds);
+        return null;
+    }
+
+    @Override
+    public void modifyAttributes(Name name, int mod_op, Attributes attrs) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            ((DirContext) this.backingContext.get()).modifyAttributes(name, mod_op, attrs);
+    }
+
+    @Override
+    public void modifyAttributes(String name, int mod_op, Attributes attrs) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            ((DirContext) this.backingContext.get()).modifyAttributes(name, mod_op, attrs);
+    }
+
+    @Override
+    public void modifyAttributes(Name name, ModificationItem[] mods) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            ((DirContext) this.backingContext.get()).modifyAttributes(name, mods);
+    }
+
+    @Override
+    public void modifyAttributes(String name, ModificationItem[] mods) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            ((DirContext) this.backingContext.get()).modifyAttributes(name, mods);
+    }
+
+    @Override
+    public void bind(Name name, Object obj, Attributes attrs) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            ((DirContext) this.backingContext.get()).bind(name, obj, attrs);
+    }
+
+    @Override
+    public void bind(String name, Object obj, Attributes attrs) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            ((DirContext) this.backingContext.get()).bind(name, obj, attrs);
+    }
+
+    @Override
+    public void rebind(Name name, Object obj, Attributes attrs) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            ((DirContext) this.backingContext.get()).rebind(name, obj, attrs);
+    }
+
+    @Override
+    public void rebind(String name, Object obj, Attributes attrs) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            ((DirContext) this.backingContext.get()).rebind(name, obj, attrs);
+    }
+
+    @Override
+    public DirContext createSubcontext(Name name, Attributes attrs) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).createSubcontext(name, attrs);
+        return null;
+    }
+
+    @Override
+    public DirContext createSubcontext(String name, Attributes attrs) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).createSubcontext(name, attrs);
+        return null;
+    }
+
+    @Override
+    public DirContext getSchema(Name name) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).getSchema(name);
+        return null;
+    }
+
+    @Override
+    public DirContext getSchema(String name) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).getSchema(name);
+        return null;
+    }
+
+    @Override
+    public DirContext getSchemaClassDefinition(Name name) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).getSchemaClassDefinition(name);
+        return null;
+    }
+
+    @Override
+    public DirContext getSchemaClassDefinition(String name) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).getSchemaClassDefinition(name);
+        return null;
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(
+            Name name, Attributes matchingAttributes, String[] attributesToReturn) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).search(name, matchingAttributes, attributesToReturn);
+        return null;
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(
+            String name, Attributes matchingAttributes, String[] attributesToReturn) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).search(name, matchingAttributes, attributesToReturn);
+        return null;
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, Attributes matchingAttributes) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).search(name, matchingAttributes);
+        return null;
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, Attributes matchingAttributes) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).search(name, matchingAttributes);
+        return null;
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, String filter, SearchControls cons)
+            throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).search(name, filter, cons);
+        return null;
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons)
+            throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).search(name, filter, cons);
+        return null;
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(
+            Name name, String filterExpr, Object[] filterArgs, SearchControls cons) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).search(name, filterExpr, filterArgs, cons);
+        return null;
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(
+            String name, String filterExpr, Object[] filterArgs, SearchControls cons) throws NamingException {
+        if (this.backingContext.get() instanceof DirContext)
+            return ((DirContext) this.backingContext.get()).search(name, filterExpr, filterArgs, cons);
+        return null;
     }
 }
 


### PR DESCRIPTION
## Purpose
When configuring databases with LDAP, the following exception occurs as the `WrapperContext` doesn't implement the `DirContext`.

```
oracle.net.ns.NetException: JNDI Package failure javax.naming.NotContextException: Not an instance of DirContext
```

## Goals
This PR resolves the above issue by implementing `DirContext` in the `WrapperContext` class.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes